### PR TITLE
feat: 환경설정, 회원가입/로그인, JWT 인증 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,8 +33,13 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
     // API Documentation
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/khmall/KhMallApplication.java
+++ b/src/main/java/com/khmall/KhMallApplication.java
@@ -2,8 +2,10 @@ package com.khmall;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class KhMallApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/khmall/api/AuthController.java
+++ b/src/main/java/com/khmall/api/AuthController.java
@@ -1,0 +1,37 @@
+package com.khmall.api;
+
+import com.khmall.domain.user.UserService;
+import com.khmall.domain.user.dto.LoginRequest;
+import com.khmall.domain.user.dto.SignupRequest;
+import com.khmall.domain.user.dto.TokenResponse;
+import com.khmall.domain.user.dto.UserResponse;
+import com.khmall.security.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+  private final UserService userService;
+  private final JwtProvider jwtProvider;
+
+  @PostMapping("/signup")
+  public ResponseEntity<UserResponse> signup(@RequestBody SignupRequest req) {
+    UserResponse user = userService.signup(req);
+    return ResponseEntity.ok(user);
+  }
+
+  @PostMapping("/login")
+  public ResponseEntity<TokenResponse> login(@RequestBody LoginRequest req) {
+    UserResponse user = userService.login(req);
+    System.out.println("User logged in: " + user.username());
+    String token = jwtProvider.createToken(user.username(), user.role().name());
+    return ResponseEntity.ok(new TokenResponse(token));
+  }
+}

--- a/src/main/java/com/khmall/api/AuthController.java
+++ b/src/main/java/com/khmall/api/AuthController.java
@@ -6,7 +6,10 @@ import com.khmall.domain.user.dto.SignupRequest;
 import com.khmall.domain.user.dto.TokenResponse;
 import com.khmall.domain.user.dto.UserResponse;
 import com.khmall.security.JwtProvider;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,19 +21,21 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/auth")
 public class AuthController {
 
+  private final Logger logger = LoggerFactory.getLogger(AuthController.class);
+
   private final UserService userService;
   private final JwtProvider jwtProvider;
 
   @PostMapping("/signup")
-  public ResponseEntity<UserResponse> signup(@RequestBody SignupRequest req) {
+  public ResponseEntity<UserResponse> signup(@Valid @RequestBody SignupRequest req) {
     UserResponse user = userService.signup(req);
     return ResponseEntity.ok(user);
   }
 
   @PostMapping("/login")
-  public ResponseEntity<TokenResponse> login(@RequestBody LoginRequest req) {
+  public ResponseEntity<TokenResponse> login(@Valid @RequestBody LoginRequest req) {
     UserResponse user = userService.login(req);
-    System.out.println("User logged in: " + user.username());
+    logger.debug("User logged in: {}", user.username());
     String token = jwtProvider.createToken(user.username(), user.role().name());
     return ResponseEntity.ok(new TokenResponse(token));
   }

--- a/src/main/java/com/khmall/common/BaseTimeEntity.java
+++ b/src/main/java/com/khmall/common/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.khmall.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseTimeEntity {
+
+  @CreatedDate
+  @Column(name = "created_at", updatable = false, nullable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(name = "updated_at", nullable = false)
+  private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/khmall/common/constants/AuthConstants.java
+++ b/src/main/java/com/khmall/common/constants/AuthConstants.java
@@ -1,12 +1,13 @@
 package com.khmall.common.constants;
 
-public final class AuthConstants {
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
-  private AuthConstants() {
-    // 인스턴스화 방지
-  }
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class AuthConstants {
 
   public static final String AUTH_HEADER = "Authorization";
   public static final String TOKEN_PREFIX = "Bearer ";
   public static final int TOKEN_PREFIX_LENGTH = TOKEN_PREFIX.length();
+  public static final long TOKEN_EXPIRATION_TIME = 1000 * 60 * 60 * 24L; // 24h
 }

--- a/src/main/java/com/khmall/common/constants/AuthConstants.java
+++ b/src/main/java/com/khmall/common/constants/AuthConstants.java
@@ -1,0 +1,12 @@
+package com.khmall.common.constants;
+
+public final class AuthConstants {
+
+  private AuthConstants() {
+    // 인스턴스화 방지
+  }
+
+  public static final String AUTH_HEADER = "Authorization";
+  public static final String TOKEN_PREFIX = "Bearer ";
+  public static final int TOKEN_PREFIX_LENGTH = TOKEN_PREFIX.length();
+}

--- a/src/main/java/com/khmall/config/SecurityConfig.java
+++ b/src/main/java/com/khmall/config/SecurityConfig.java
@@ -1,0 +1,15 @@
+package com.khmall.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+}

--- a/src/main/java/com/khmall/config/SecurityConfig.java
+++ b/src/main/java/com/khmall/config/SecurityConfig.java
@@ -1,12 +1,49 @@
 package com.khmall.config;
 
+import com.khmall.security.JwtAuthenticationFilter;
+import com.khmall.security.JwtProvider;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+  private final JwtProvider jwtProvider;
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http
+        // CSRF 보호 비활성화
+        .csrf(AbstractHttpConfigurer::disable)
+
+        // 세션을 완전히 사용하지 않도록(STATELESS) 설정
+        .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+        // URL 인증/인가 설정
+        .authorizeHttpRequests(auth -> auth
+            // /api/auth/** 경로(회원가입, 로그인)는 인증 없이 접근 허용
+            .requestMatchers("/api/auth/**").permitAll()
+            // 나머지 모든 요청은 인증 필요(JWT 없으면 401)
+            .anyRequest().authenticated())
+
+        // JWT 인증 필터를 UsernamePasswordAuthenticationFilter 앞에 추가 (실제 인증은 JWT로만)
+        .addFilterBefore(
+            new JwtAuthenticationFilter(jwtProvider),
+            UsernamePasswordAuthenticationFilter.class);
+
+    return http.build();
+  }
 
   @Bean
   public PasswordEncoder passwordEncoder() {

--- a/src/main/java/com/khmall/domain/user/Role.java
+++ b/src/main/java/com/khmall/domain/user/Role.java
@@ -1,0 +1,6 @@
+package com.khmall.domain.user;
+
+public enum Role {
+  USER,
+  ADMIN
+}

--- a/src/main/java/com/khmall/domain/user/User.java
+++ b/src/main/java/com/khmall/domain/user/User.java
@@ -1,0 +1,42 @@
+package com.khmall.domain.user;
+
+import com.khmall.common.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@Entity
+@Table(name = "user")
+@NoArgsConstructor
+@AllArgsConstructor
+public class User extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long userId;
+
+  @Column(nullable = false, length = 60, unique = true)
+  private String username;
+
+  @Column(nullable = false, length = 255)
+  private String password;
+
+  @Column(nullable = false, length = 60)
+  private String name;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private Role role;
+
+}

--- a/src/main/java/com/khmall/domain/user/UserMapper.java
+++ b/src/main/java/com/khmall/domain/user/UserMapper.java
@@ -1,0 +1,26 @@
+package com.khmall.domain.user;
+
+import com.khmall.domain.user.dto.SignupRequest;
+import com.khmall.domain.user.dto.UserResponse;
+
+public class UserMapper {
+
+  public static UserResponse toResponse(User user) {
+    return new UserResponse(
+        user.getUserId(),
+        user.getUsername(),
+        user.getName(),
+        user.getRole()
+    );
+  }
+
+  public static User toEntity(SignupRequest request, String encodedPassword) {
+    return User.builder()
+        .username(request.username())
+        .password(encodedPassword)
+        .name(request.name())
+        .role(Role.USER) // 기본 역할은 USER로 설정
+        .build();
+  }
+
+}

--- a/src/main/java/com/khmall/domain/user/UserRepository.java
+++ b/src/main/java/com/khmall/domain/user/UserRepository.java
@@ -1,0 +1,14 @@
+package com.khmall.domain.user;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+  // 아이디 중복 체크를 위한 메소드
+  boolean existsByUsername(String username);
+
+  // 로그인 시 사용할 메소드
+  Optional<User> findByUsername(String username);
+
+}

--- a/src/main/java/com/khmall/domain/user/UserService.java
+++ b/src/main/java/com/khmall/domain/user/UserService.java
@@ -1,0 +1,53 @@
+package com.khmall.domain.user;
+
+import com.khmall.domain.user.dto.LoginRequest;
+import com.khmall.domain.user.dto.SignupRequest;
+import com.khmall.domain.user.dto.UserResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+  private final UserRepository userRepository;
+  private final PasswordEncoder passwordEncoder;
+
+  /**
+   * 회원 가입을 처리합니다.
+   *
+   * @param request 회원 가입 요청 정보
+   * @return 가입된 사용자 정보
+   * @throws IllegalArgumentException 이미 사용 중인 아이디일 경우
+   */
+  @Transactional
+  public UserResponse signup(SignupRequest request) {
+    if (userRepository.existsByUsername(request.username())) {
+      throw new IllegalArgumentException("이미 사용 중인 아이디입니다.");
+    }
+    String encodedPassword = passwordEncoder.encode(request.password());
+    User user = UserMapper.toEntity(request, encodedPassword);
+    User saved = userRepository.save(user);
+    return UserMapper.toResponse(saved);
+  }
+
+  /**
+   * 로그인 처리를 합니다.
+   *
+   * @param request 로그인 요청 정보
+   * @return 로그인된 사용자 정보
+   * @throws IllegalArgumentException 아이디가 존재하지 않거나 비밀번호가 일치하지 않을 경우
+   */
+  public UserResponse login(LoginRequest request) {
+    User user = userRepository.findByUsername(request.username())
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+    if (!passwordEncoder.matches(request.password(), user.getPassword())) {
+      throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+    }
+
+    return UserMapper.toResponse(user);
+  }
+}

--- a/src/main/java/com/khmall/domain/user/dto/LoginRequest.java
+++ b/src/main/java/com/khmall/domain/user/dto/LoginRequest.java
@@ -1,0 +1,9 @@
+package com.khmall.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+    @NotBlank String username,
+    @NotBlank String password) {
+
+}

--- a/src/main/java/com/khmall/domain/user/dto/SignupRequest.java
+++ b/src/main/java/com/khmall/domain/user/dto/SignupRequest.java
@@ -1,0 +1,10 @@
+package com.khmall.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record SignupRequest(
+    @NotBlank String username,
+    @NotBlank String password,
+    @NotBlank String name) {
+
+}

--- a/src/main/java/com/khmall/domain/user/dto/TokenResponse.java
+++ b/src/main/java/com/khmall/domain/user/dto/TokenResponse.java
@@ -1,0 +1,7 @@
+package com.khmall.domain.user.dto;
+
+public record TokenResponse(
+    String token
+) {
+
+}

--- a/src/main/java/com/khmall/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/khmall/domain/user/dto/UserResponse.java
@@ -1,0 +1,12 @@
+package com.khmall.domain.user.dto;
+
+import com.khmall.domain.user.Role;
+
+public record UserResponse(
+    Long userId,
+    String username,
+    String name,
+    Role role
+) {
+
+}

--- a/src/main/java/com/khmall/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/khmall/security/JwtAuthenticationFilter.java
@@ -1,0 +1,44 @@
+package com.khmall.security;
+
+import com.khmall.common.constants.AuthConstants;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+  private final JwtProvider jwtProvider;
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+
+    String header = request.getHeader(AuthConstants.AUTH_HEADER);
+    if (header != null && header.startsWith(AuthConstants.TOKEN_PREFIX)) {
+      String token = header.substring(AuthConstants.TOKEN_PREFIX_LENGTH);
+
+      if (jwtProvider.validateToken(token)) {
+        String username = jwtProvider.getUsername(token);
+        String role = jwtProvider.getRole(token);
+
+        UsernamePasswordAuthenticationToken authentication =
+            new UsernamePasswordAuthenticationToken(
+                username,
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_" + role))
+            );
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+      }
+    }
+    filterChain.doFilter(request, response);
+  }
+}

--- a/src/main/java/com/khmall/security/JwtProvider.java
+++ b/src/main/java/com/khmall/security/JwtProvider.java
@@ -1,5 +1,6 @@
 package com.khmall.security;
 
+import com.khmall.common.constants.AuthConstants;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
@@ -22,9 +23,7 @@ public class JwtProvider {
   // JWT 토큰 생성
   public String createToken(String username, String role) {
     Date now = new Date();
-    // 24시간
-    long validityInMs = 1000 * 60 * 60 * 24L;
-    Date validity = new Date(now.getTime() + validityInMs);
+    Date validity = new Date(now.getTime() + AuthConstants.TOKEN_EXPIRATION_TIME);
 
     return Jwts.builder()
         .subject(username)

--- a/src/main/java/com/khmall/security/JwtProvider.java
+++ b/src/main/java/com/khmall/security/JwtProvider.java
@@ -1,0 +1,66 @@
+package com.khmall.security;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtProvider {
+
+  private final SecretKey secretKey;
+
+  private static final String ROLE_CLAIM = "role";
+
+  public JwtProvider(@Value("${jwt.secret}") String secret) {
+    this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+  }
+
+  // JWT 토큰 생성
+  public String createToken(String username, String role) {
+    Date now = new Date();
+    // 24시간
+    long validityInMs = 1000 * 60 * 60 * 24L;
+    Date validity = new Date(now.getTime() + validityInMs);
+
+    return Jwts.builder()
+        .subject(username)
+        .claim(ROLE_CLAIM, role)
+        .issuedAt(now)
+        .expiration(validity)
+        .signWith(secretKey)
+        .compact();
+  }
+
+  // 토큰에서 Payload 추출
+  private Claims getClaims(String token) {
+    return Jwts.parser()
+        .verifyWith(secretKey)
+        .build()
+        .parseSignedClaims(token)
+        .getPayload();
+  }
+
+  // 사용자명 추출
+  public String getUsername(String token) {
+    return getClaims(token).getSubject();
+  }
+
+  // 역할(role) 추출
+  public String getRole(String token) {
+    return getClaims(token).get(ROLE_CLAIM, String.class);
+  }
+
+  // 토큰 유효성 검사
+  public boolean validateToken(String token) {
+    try {
+      getClaims(token);
+      return true;
+    } catch (JwtException | IllegalArgumentException e) {
+      return false;
+    }
+  }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -4,7 +4,7 @@ spring:
       on-profile: local
 
   datasource:
-    url: jdbc:mysql://localhost:3306/khmall?characterEncoding=utf8mb4&serverTimezone=Asia/Seoul
+    url: jdbc:mysql://localhost:3306/khmall?serverTimezone=Asia/Seoul
     username: ${DB_MYSQL_USER}
     password: ${DB_MYSQL_PASS}
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,19 @@
+spring:
+  config:
+    activate:
+      on-profile: local
+
+  datasource:
+    url: jdbc:mysql://localhost:3306/khmall?characterEncoding=utf8mb4&serverTimezone=Asia/Seoul
+    username: ${DB_MYSQL_USER}
+    password: ${DB_MYSQL_PASS}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL8Dialect
+        show_sql: true
+        format_sql: true

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -11,9 +11,13 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
         show_sql: true
         format_sql: true
+logging:
+  level:
+    root: info
+    com.khmall: debug

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=KHMall

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,6 @@
+spring:
+  profiles:
+    default: local
+
+server:
+  port: 8080

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,5 +2,8 @@ spring:
   profiles:
     default: local
 
+jwt:
+  secret: ${JWT_SECRET}
+
 server:
   port: 8080

--- a/src/test/java/com/khmall/user/JwtProviderTest.java
+++ b/src/test/java/com/khmall/user/JwtProviderTest.java
@@ -1,0 +1,66 @@
+package com.khmall.user;
+
+import com.khmall.security.JwtProvider;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class JwtProviderTest {
+  private final String secret = "testtesttesttesttesttesttesttest1234";
+  private final JwtProvider jwtProvider = new JwtProvider(secret);
+
+  @Test
+  void 토큰_정상생성_파싱_성공() {
+    // Given
+    String username = "tester";
+    String role = "ADMIN";
+
+    // When
+    String token = jwtProvider.createToken(username, role);
+
+    // Then
+    assertTrue(jwtProvider.validateToken(token));
+    assertEquals(username, jwtProvider.getUsername(token));
+    assertEquals(role, jwtProvider.getRole(token));
+  }
+
+  @Test
+  void 시크릿키가_다르면_토큰_검증_실패() {
+    // Given
+    String secretB = "differentdifferentdifferentdifferent9876";
+    JwtProvider jwtProviderA = new JwtProvider(secret);
+    JwtProvider jwtProviderB = new JwtProvider(secretB);
+
+    String token = jwtProviderA.createToken("tester", "ADMIN");
+
+    // When & Then
+    assertFalse(jwtProviderB.validateToken(token));
+    assertThrows(Exception.class, () -> jwtProviderB.getUsername(token));
+    assertThrows(Exception.class, () -> jwtProviderB.getRole(token));
+  }
+
+  @Test
+  void 만료된_토큰_검증_실패() throws InterruptedException {
+    // Given
+    String secret = "testtesttesttesttesttesttesttest1234";
+    JwtProvider jwtProvider = new JwtProvider(secret);
+
+    // 토큰 만료시간을 매우 짧게 설정해서 생성
+    String token = Jwts.builder()
+        .subject("tester")
+        .claim("role", "ADMIN")
+        .issuedAt(new Date())
+        .expiration(new Date(System.currentTimeMillis() + 100)) // 0.1초 후 만료
+        .signWith(Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8)))
+        .compact();
+
+    Thread.sleep(200); // 토큰이 만료되길 기다림
+
+    // When & Then
+    assertFalse(jwtProvider.validateToken(token));
+    assertThrows(Exception.class, () -> jwtProvider.getUsername(token));
+  }
+}

--- a/src/test/java/com/khmall/user/UserServiceTest.java
+++ b/src/test/java/com/khmall/user/UserServiceTest.java
@@ -1,0 +1,79 @@
+package com.khmall.user;
+
+import com.khmall.domain.user.Role;
+import com.khmall.domain.user.UserRepository;
+import com.khmall.domain.user.UserService;
+import com.khmall.domain.user.dto.LoginRequest;
+import com.khmall.domain.user.dto.SignupRequest;
+import com.khmall.domain.user.dto.UserResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class UserServiceTest {
+
+  @Autowired
+  UserService userService;
+
+  @Autowired
+  UserRepository userRepository;
+
+  @Test
+  void 회원가입_성공() {
+    // Given: 회원가입 요청 DTO 준비
+    SignupRequest request = new SignupRequest(
+        "tester",
+        "password123",
+        "홍길동"
+    );
+    // When: 회원가입 수행
+    UserResponse response = userService.signup(request);
+
+    // Then: 응답 검증
+    assertEquals("tester", response.username());
+    assertEquals("홍길동", response.name());
+    assertEquals(Role.USER, response.role());
+  }
+
+  @Test
+  void 로그인_성공() {
+    // Given: 사전에 회원가입을 수행
+    userService.signup(new SignupRequest("loginuser", "pw", "이름"));
+
+    // When: 로그인 요청
+    LoginRequest req = new LoginRequest("loginuser", "pw");
+    UserResponse resp = userService.login(req);
+
+    // Then: 결과 검증
+    assertEquals("loginuser", resp.username());
+  }
+
+  @Test
+  void 아이디_중복_에러() {
+    // Given: 이미 존재하는 아이디로 회원가입
+    userService.signup(new SignupRequest("dup", "pw", "a"));
+
+    // When & Then: 같은 아이디로 다시 가입 시도 → 예외 발생
+    SignupRequest req = new SignupRequest("dup", "pw", "b");
+    assertThrows(IllegalArgumentException.class, () ->
+        userService.signup(req)
+    );
+  }
+
+  @Test
+  void 비밀번호_불일치_에러() {
+    // Given: 회원가입 완료
+    userService.signup(new SignupRequest("pwtest", "pw1", "a"));
+
+    // When & Then: 잘못된 비밀번호로 로그인 시도 → 예외 발생
+    LoginRequest req = new LoginRequest("pwtest", "wrongpw");
+    assertThrows(IllegalArgumentException.class, () ->
+        userService.login(req)
+    );
+  }
+}


### PR DESCRIPTION
### 변경사항
**AS-IS**
- Spring Boot 프로젝트 초기 상태. `application.properties` 파일만 존재하고, 설정 내용 없음.
- 회원/인증/인가 관련 기능 미구현.

**TO-BE**
- 환경설정 파일 구조 개선  
    - `application.yml`(기본 프로필), `application-local.yml`(로컬 개발환경)로 분리
    - DB(MySQL), JPA, JWT, 서버 포트 등 환경별 설정 추가
    - DB 계정/비밀번호 환경변수(`DB_MYSQL_USER`, `DB_MYSQL_PASS`)로 관리
    - JWT 시크릿 환경변수(`JWT_SECRET`)는 랜덤 base64 문자열로 생성해서 등록 후 관리
- 회원가입/로그인 API 구현  
   - 회원가입: username/password 입력, BCrypt 암호화 후 DB의 user 테이블에 신규 저장
   - 로그인: DB의 user 테이블에 저장된 회원 정보로 인증 및 JWT 토큰 발급
   - 권한(role)은 USER/ADMIN으로 구분
- JWT 인증/인가 적용  
    - JWT 토큰 기반 인증 필터 및 권한 부여

### 테스트
- [x] 테스트 코드: 회원가입/로그인/토큰 검증 단위 테스트 작성 및 실행
- [x] API 테스트: Postman을 통한 전체 인증 플로우 정상 동작 확인